### PR TITLE
Clearing hadrons if there are no connected lines found on a stateline…

### DIFF
--- a/Scenes_and_scripts/Diagram/StateLine.gd
+++ b/Scenes_and_scripts/Diagram/StateLine.gd
@@ -54,6 +54,7 @@ func queue_update() -> void:
 func update() -> void:
 	var connected_lines := get_connected_lines()
 	if connected_lines.size() == 0:
+		clear_hadrons()
 		return
 
 	update_hadrons(get_quark_groups(connected_lines))


### PR DESCRIPTION
…, removing empty hadron joints

closes #80 