### PR TITLE
fixed 4-vertex ABC error

### DIFF
--- a/Scenes_and_scripts/Algorithms/SolutionGeneration.gd
+++ b/Scenes_and_scripts/Algorithms/SolutionGeneration.gd
@@ -331,10 +331,7 @@ func connect_matrix(base_matrix: InteractionMatrix) -> Array[InteractionMatrix]:
 	
 	if found_one:
 		return []
-	
-	##TODO
-	#if base_matrix.connection_matrix.size() == 6 && base_matrix.get_unconnected_particles() == [ParticleData.Particle.H, ParticleData.Particle.Z]:
-		#1 == 1
+
 		
 	for from_id:int in entry_ids:
 		var further_matrices: Array[InteractionMatrix] = []
@@ -1436,7 +1433,7 @@ func connect_3_particles_to_ids(
 					connect_particle_to_ids(
 						particleC,
 						from_id,
-						particleA_connected_matrix,
+						particle_AB_connected_matrix,
 						to_ids
 					)
 				)

--- a/Scenes_and_scripts/Diagram/main_diagram.gd
+++ b/Scenes_and_scripts/Diagram/main_diagram.gd
@@ -377,6 +377,12 @@ func update_vision() -> void:
 	if get_interactions().size() == 0:
 		return
 	
+	if get_interactions().any(
+		func(interaction:Interaction) -> bool:
+			return !interaction.valid
+	):
+		return
+	
 	var valid_diagram: DrawingMatrix = generate_drawing_matrix_from_diagram(true)
 	
 	update_colour(valid_diagram)


### PR DESCRIPTION
when connecting all particles of a 4-vertex, connecting particle C would connect from A-connected matrices not AB-connected matrices.