### PR TITLE
Interaction strength for general particles

### DIFF
--- a/Scenes_and_scripts/Autoloads/ParticleData.gd
+++ b/Scenes_and_scripts/Autoloads/ParticleData.gd
@@ -1202,6 +1202,11 @@ func is_general(particle: ParticleData.Particle) -> bool:
 func is_particle(particleA: ParticleData.Particle, particleB: ParticleData.Particle) -> bool:
 	return base(particleA) == particleB
 
+func convert_particle(particle: ParticleData.Particle) -> ParticleData.Particle:
+	if base(particle) in GENERAL_CONVERSION.keys():
+		return sign(particle) * GENERAL_CONVERSION[base(particle)][-1]
+	return particle
+
 func general_can_convert(
 	from_particle: ParticleData.Particle,
 	to_particle: ParticleData.Particle

--- a/Scenes_and_scripts/Diagram/interaction.gd
+++ b/Scenes_and_scripts/Diagram/interaction.gd
@@ -496,6 +496,12 @@ func drop() -> void:
 
 func get_interaction_index() -> Array[int]:
 	var sorted_connected_base_particles := self.connected_base_particles.duplicate(true)
+	
+	for i:int in sorted_connected_base_particles.size():
+		var particle: ParticleData.Particle = sorted_connected_base_particles[i]
+		if ParticleData.is_general(particle):
+			sorted_connected_base_particles[i] = ParticleData.convert_particle(particle)
+	
 	sorted_connected_base_particles.sort()
 	
 	for i:int in range(ParticleData.INTERACTIONS.size()):


### PR DESCRIPTION
Interactions will now convert general particles to tau, tau neutrino, top, bottom before calculating interaction strength.

Fixes #94 