### PR TITLE
Lower maxmimum particle count from 8 to 6

### DIFF
--- a/Scenes_and_scripts/UI/Menus/PuzzleUI.gd
+++ b/Scenes_and_scripts/UI/Menus/PuzzleUI.gd
@@ -3,7 +3,7 @@ extends PullOutTab
 enum HadronFrequency {Always, Allowed, Never}
 
 @export var MINIMUM_PARTICLE_COUNT: int = 2
-@export var MAXIMUM_PARTICLE_COUNT: int = 8
+@export var MAXIMUM_PARTICLE_COUNT: int = 6
 @export var STARTING_MAX_PARTICLE_COUNT: int = 6
 
 @export var HadronFrequencySlider: HSlider


### PR DESCRIPTION
Raising particle count to 8 seems entirely unnecessary, and will always cause lag. Unlike solution generation, I see no reason to keep such a high ceiling.